### PR TITLE
MASST logo included

### DIFF
--- a/docs/masst.md
+++ b/docs/masst.md
@@ -1,3 +1,5 @@
+![logo](docs/img/logo/MASST_logo_with_url.png)
+
 ## Overview
 
 Query a single MS/MS spectrum across all public GNPS datasets. The mass spectrometry equivalent of NCBI BLAST helps to put the query spectrum in context of where else it occurs (including sample information) as well as search a single MS/MS spectrum against all public spectral libraries.


### PR DESCRIPTION
MASST logo at the beginning of the documentation.