### PR TITLE
Added description for m/z values drift correction

### DIFF
--- a/docs/fileconversion_waters.md
+++ b/docs/fileconversion_waters.md
@@ -60,6 +60,9 @@ There is a known issue on precursor ion m/z values when Waters .Raw data are con
 
 If we will use the FBMN workflow, you can detour this issue by using .Raw files for MZmine processing, without converting them to .mzML files. However, the direct import of Waters .Raw into MZmine is not possible in MZmine ver 2.53 due to a bug; so try it with old releases.
 
+## 4. Precursor m/z values drift problem
+As mentioned before, m/z values of precursor ions in .mzML and .mzXML files can be different from the real value. The script that can actually fix this problem on .mzXML files can be found [there](https://github.com/elnurgar/mzxml-precursor-corrector).
+
 ## Page Contributors
 
 {{ git_page_authors }}


### PR DESCRIPTION
Added description about precursors m/z values drift. Actually it works only with .mzXML files. The work on the fix of .mzML files is in progress.